### PR TITLE
make kernel32 interop optional to support linux (and probably macOS)

### DIFF
--- a/TrueColorConsoleApp/Program.cs
+++ b/TrueColorConsoleApp/Program.cs
@@ -76,26 +76,31 @@ namespace TrueColorConsoleApp
         private static void Example3()
         {
             var plasma = new Plasma(256, 256);
-            var width = 80;
-            var height = 40;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Console.SetWindowSize(width, height);
-                Console.SetBufferSize(width, height);
-                Console.SetWindowSize(width, height); // removes bars
-            }
             Console.Title = "Plasma !";
             Console.CursorVisible = false;
 
+            var width = Console.WindowWidth;
+            var height = Console.WindowHeight;
             var builder = new StringBuilder(width * height * 22);
+            var resetEvent = new AutoResetEvent(true);
 
+            using(new Timer(x =>{resetEvent.Set();}, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(1.0/20*1000)))
             for (var frame = 0; ; frame++)
             {
+                if (width != Console.WindowWidth || height != Console.WindowHeight)
+                {
+                    width = Console.WindowWidth;
+                    height = Console.WindowHeight;
+                    Console.WriteLine();
+                    builder = new StringBuilder(width * height * 22);
+                }
+                else
+                {
+                    builder.Clear();
+                }
                 plasma.PlasmaFrame(frame);
-                builder.Clear();
                 
-                Thread.Sleep((int)(1.0 / 20 * 1000));
+                resetEvent.WaitOne();
                 
                 for (var i = 0; i < width * height; i++)
                 {

--- a/TrueColorConsoleApp/Program.cs
+++ b/TrueColorConsoleApp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using TrueColorConsole;
@@ -78,9 +79,12 @@ namespace TrueColorConsoleApp
             var width = 80;
             var height = 40;
 
-            Console.SetWindowSize(width, height);
-            Console.SetBufferSize(width, height);
-            Console.SetWindowSize(width, height); // removes bars
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Console.SetWindowSize(width, height);
+                Console.SetBufferSize(width, height);
+                Console.SetWindowSize(width, height); // removes bars
+            }
             Console.Title = "Plasma !";
             Console.CursorVisible = false;
 


### PR DESCRIPTION
This PR moves all interop calls to nested `NativeMethods` to prevent the runtime from trying to load the `kernel32.dll` on non windows systems and also adds a few Platform checks to just skip the windows specific calls.
I had to disable the console resize for the plasma demo, since this is not supported on linux.

I've succesfully tested the plasma demo with this patch under dotnet 2.1.3 running on Ubuntu 16.04.5 LTS using the latest PuTTY snapshot `Development snapshot 2018-08-26.6c924ba` ([True Color support was added after the latest stable release 0.70](https://www.chiark.greenend.org.uk/~sgtatham/putty/wishlist/true-colour.html)).

`WriteFast` seems to be superflous on linux - the plasma demo produced 10MBit/s of network traffic and showed only some small artifacts.

Sadly I don't own an apple device, so I was not able to test this on macOS.

![grafik](https://user-images.githubusercontent.com/6039253/45109159-f4537900-b13e-11e8-95f6-abd1401dccae.png)