### PR TITLE
Stylesheet support

### DIFF
--- a/TrueColorConsole/StyleRule.cs
+++ b/TrueColorConsole/StyleRule.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace TrueColorConsole.Styled {
+	public interface iRule {
+		void ApplyRuleToSegments(List<SegmentItem> items);
+	}
+	public class FormatRule : RawRule {
+		public FormatRule(Regex regex, IEnumerable<VTFormat> before, IEnumerable<VTFormat> after, Func<string, string> match_replace = null)
+			: base(regex, new Action[] { () => VTConsole.SetFormat(before.ToArray()) }, new Action[] { () => VTConsole.SetFormat(after.ToArray()) }, match_replace) {
+		}
+	}
+	public class RawRule : iRule {
+		public string only_use_capture_group_name;//if set only operate on this capture group rather than entire match
+		public RawRule(Regex regex, IEnumerable<Action> before, IEnumerable<Action> after, Func<string, string> match_replace = null) {
+			this.regex = regex;
+			this.match_replace = match_replace;
+			this.before_cmds = before;
+			this.after_cmds = after;
+		}
+		public void ApplyRuleToSegments(List<SegmentItem> items) {
+			foreach (var item in items.ToArray()) {
+				var cur_item = item;
+				var matches = regex.Matches(cur_item.str);
+				foreach (var entire_match in matches.Cast<Match>().OrderByDescending(a => a.Index)) {//need to work back to front, do we?
+					if (!entire_match.Success)
+						continue;
+					var match = string.IsNullOrWhiteSpace(only_use_capture_group_name) ? entire_match.Groups[only_use_capture_group_name] : entire_match;
+					var pos = match.Index;
+					//So we want to allow other items affecting the segment( ie uderline bg color etc) to conintue through that we don't set
+					var before_segment = new SegmentItem { str = cur_item.str.Substring(0, pos), before = cur_item.before };
+					var after_segment = new SegmentItem { str = cur_item.str.Substring(pos + match.Length), after = cur_item.after };
+					//even if there is nothing before or after we want to add them for styling
+					items.Insert(items.IndexOf(cur_item) + 1, after_segment);
+					items.Insert(items.IndexOf(cur_item), before_segment);
+
+					cur_item.str = cur_item.str.Substring(pos, match.Length);
+
+					if (match_replace != null)
+						cur_item.str = match_replace(cur_item.str);
+
+					cur_item.before = before_cmds;
+					cur_item.after = after_cmds;
+					cur_item = before_segment;//we work back to front
+				}
+			}
+		}
+		protected IEnumerable<Action> before_cmds;
+		protected IEnumerable<Action> after_cmds;
+		protected Func<string, string> match_replace;
+		protected Regex regex;
+	}
+	public class StyleRule : RawRule {
+		public StyleRule(String regex, Color foreground_color, Func<string, string> match_replace = null, Color? background_color = null) : this(new Regex(regex), foreground_color, match_replace, background_color) {
+
+		}
+		protected static IEnumerable<Action> GetCommands(Color foreground_color, Color? background_color, bool need_after) {
+			var cmds = new List<Action>();
+			if (foreground_color != Color.Empty && foreground_color != Color.Transparent) {
+				if (!need_after)
+					cmds.Add(() => VTConsole.SetColorForeground(foreground_color));
+				else
+					cmds.Add(() => VTConsole.PopForegroundColor());
+			}
+			if (background_color != null && background_color != Color.Empty && background_color != Color.Transparent) {
+				if (!need_after)
+					cmds.Add(() => VTConsole.SetColorBackground(background_color.Value));
+				else
+					cmds.Add(() => VTConsole.PopBackgroundColor());
+			}
+
+			return cmds;
+		}
+		public StyleRule(Regex regex, Color foreground_color, Func<string, string> match_replace = null, Color? background_color = null) :
+			base(regex, GetCommands(foreground_color, background_color, false), GetCommands(foreground_color, background_color, true), match_replace) {
+
+		}
+
+
+	}
+
+}

--- a/TrueColorConsole/StyleRule.cs
+++ b/TrueColorConsole/StyleRule.cs
@@ -28,7 +28,7 @@ namespace TrueColorConsole.Styled {
 				foreach (var entire_match in matches.Cast<Match>().OrderByDescending(a => a.Index)) {//need to work back to front, do we?
 					if (!entire_match.Success)
 						continue;
-					var match = string.IsNullOrWhiteSpace(only_use_capture_group_name) ? entire_match.Groups[only_use_capture_group_name] : entire_match;
+					var match = ! string.IsNullOrWhiteSpace(only_use_capture_group_name) ? entire_match.Groups[only_use_capture_group_name] : entire_match;
 					var pos = match.Index;
 					//So we want to allow other items affecting the segment( ie uderline bg color etc) to conintue through that we don't set
 					var before_segment = new SegmentItem { str = cur_item.str.Substring(0, pos), before = cur_item.before };

--- a/TrueColorConsole/StyleSheet.cs
+++ b/TrueColorConsole/StyleSheet.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+using TrueColorConsole;
+
+namespace TrueColorConsole.Styled {
+	public class StyleSheet {
+		public StyleSheet() { }
+		public StyleSheet(Color default_color) {
+			this.default_color = default_color;
+		}
+		public Color default_color = Color.Empty;
+		public List<iRule> rules = new List<iRule>();
+		public void AddStyle(iRule rule) => rules.Add(rule);
+		public IEnumerable<SegmentItem> ApplyRules(String str) {
+			var items = new List<SegmentItem>();
+			var def = new SegmentItem {str=str };
+			if (default_color != Color.Empty && default_color != Color.Transparent) {
+				def.before = new Action[] { () => VTConsole.SetColorForeground(default_color) };
+				def.after = new Action[] { () => VTConsole.PopForegroundColor() };
+			}
+			items.Add(def);
+			foreach (var rule in rules)
+				rule.ApplyRuleToSegments(items);
+			return items;
+		}
+	}
+	public class SegmentItem {
+		public string str;
+		public IEnumerable<Action> before;
+		public IEnumerable<Action> after;
+	}
+
+}

--- a/TrueColorConsole/VTConsole.Styled.cs
+++ b/TrueColorConsole/VTConsole.Styled.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+using TrueColorConsole.Styled;
+namespace TrueColorConsole {
+	partial class VTConsole {
+		public static void WriteStyled(String value, StyleSheet styleSheet) {
+			track_color_history = true;
+			var items = styleSheet.ApplyRules(value);
+			foreach (var item in items) {
+				if (item.before != null)
+					foreach (var action in item.before)
+						action();
+				Console.Write(item.str);
+				if (item.after != null)
+					foreach (var action in item.after)
+						action();
+			}
+			SetFormat(VTFormat.Default);
+			track_color_history = false;
+			foreground_color_history.Clear();
+			background_color_history.Clear();
+		}
+		public static void WriteLineStyled(string value, StyleSheet styleSheet) {
+			WriteStyled(value, styleSheet);
+			Console.WriteLine();
+		}
+		private static ConcurrentStack<Color> foreground_color_history = new ConcurrentStack<Color>();
+		private static ConcurrentStack<Color> background_color_history = new ConcurrentStack<Color>();
+		private static bool track_color_history;
+		public static void PopForegroundColor() {
+			if (foreground_color_history.TryPop(out Color cur)) {
+				if (foreground_color_history.TryPop(out Color prev))
+					SetColorForeground(prev);//will auto requeue it
+				else//set back to default color
+					SetFormat(VTFormat.ForegroundDefault);
+
+			}
+		}
+		public static void PopBackgroundColor() {
+			if (background_color_history.TryPop(out Color cur)) {
+				if (background_color_history.TryPop(out Color prev))
+					SetColorBackground(prev);//will auto requeue it
+				else//set back to default color
+					SetFormat(VTFormat.BackgroundDefault);
+
+			}
+		}
+
+	}
+}

--- a/TrueColorConsole/VTConsole.cs
+++ b/TrueColorConsole/VTConsole.cs
@@ -261,6 +261,8 @@ namespace TrueColorConsole
         public static void SetColorBackground(Color color)
         {
             Console.Write(GetColorBackgroundString(color.R, color.G, color.B));
+            if (track_color_history)
+                background_color_history.Push(color);
         }
 
         /// <summary>
@@ -273,6 +275,8 @@ namespace TrueColorConsole
         public static void SetColorForeground(Color color)
         {
             Console.Write(GetColorForegroundString(color.R, color.G, color.B));
+            if (track_color_history)
+                foreground_color_history.Push(color);
         }
 
         /// <summary>

--- a/TrueColorConsoleApp/Program.cs
+++ b/TrueColorConsoleApp/Program.cs
@@ -76,26 +76,31 @@ namespace TrueColorConsoleApp
         private static void Example3()
         {
             var plasma = new Plasma(256, 256);
-            var width = 80;
-            var height = 40;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Console.SetWindowSize(width, height);
-                Console.SetBufferSize(width, height);
-                Console.SetWindowSize(width, height); // removes bars
-            }
             Console.Title = "Plasma !";
             Console.CursorVisible = false;
 
+            var width = Console.WindowWidth;
+            var height = Console.WindowHeight;
             var builder = new StringBuilder(width * height * 22);
+            var resetEvent = new AutoResetEvent(true);
 
+            using(new Timer(x =>{resetEvent.Set();}, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(1.0/20*1000)))
             for (var frame = 0; ; frame++)
             {
+                if (width != Console.WindowWidth || height != Console.WindowHeight)
+                {
+                    width = Console.WindowWidth;
+                    height = Console.WindowHeight;
+                    Console.WriteLine();
+                    builder = new StringBuilder(width * height * 22);
+                }
+                else
+                {
+                    builder.Clear();
+                }
                 plasma.PlasmaFrame(frame);
-                builder.Clear();
                 
-                Thread.Sleep((int)(1.0 / 20 * 1000));
+                resetEvent.WaitOne();
                 
                 for (var i = 0; i < width * height; i++)
                 {

--- a/TrueColorConsoleApp/Program.cs
+++ b/TrueColorConsoleApp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using TrueColorConsole;
@@ -78,9 +79,12 @@ namespace TrueColorConsoleApp
             var width = 80;
             var height = 40;
 
-            Console.SetWindowSize(width, height);
-            Console.SetBufferSize(width, height);
-            Console.SetWindowSize(width, height); // removes bars
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Console.SetWindowSize(width, height);
+                Console.SetBufferSize(width, height);
+                Console.SetWindowSize(width, height); // removes bars
+            }
             Console.Title = "Plasma !";
             Console.CursorVisible = false;
 

--- a/TrueColorConsoleApp/Program.cs
+++ b/TrueColorConsoleApp/Program.cs
@@ -2,8 +2,10 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using TrueColorConsole;
+using TrueColorConsole.Styled;
 
 namespace TrueColorConsoleApp
 {
@@ -11,16 +13,24 @@ namespace TrueColorConsoleApp
     {
         private static void Main(string[] args)
         {
-            if (!VTConsole.IsSupported)
-                throw new NotSupportedException();
+			if (!VTConsole.IsSupported)
+				throw new NotSupportedException();
 
-            VTConsole.Enable();
+			VTConsole.Enable();
 
-            Example3();
+			Example4();
 
             Console.ReadKey();
         }
+        private static void Example4() {
+            var st = new StyleSheet(Color.Orange);
+            st.AddStyle(new FormatRule(new Regex("hope.+SWEET"), new []{VTFormat.Underline }, new [] {VTFormat.NoUnderline }));
+            st.AddStyle(new StyleRule(new Regex("are .+"), Color.Transparent, null, Color.Red));
+            st.AddStyle(new StyleRule(new Regex(@"Happy.+going"),Color.Lime,(s)=>"Zanay how BOW how howdy"));
+            st.AddStyle(new StyleRule(new Regex("how"), Color.Blue));
+            VTConsole.WriteLineStyled("I hope you are Happy with how its going???? yah **SWEET**",st);
 
+		}
         private static int Example1()
         {
             var width = 80;


### PR DESCRIPTION
I am not sure if this project is still active, nor if this would be wanted/merged but I figured I would submit it just in case.

This is based on top of the existing linux PR here.  It could be easily rebased but at the same time it would seem that PR could be merged in.   There is no documentation on it, but it shouldn't break any of the current default functions.  It added VTConsole.WriteLineStyled and WriteStyled themed like Colorful.Console.   The syntax / class names are slightly different due to a pretty different implementation.

This allows for less manual styling and more rule based styling of output.  The order rules are added to a stylesheet matter, and rules cannot overlap with a shorter rule already applied (just won't match).

This was mainly due to https://github.com/tomakita/Colorful.Console/pull/29 being fairly stalled.  Altering the native shell color slots screws up some things like the new windows Terminal, VT colors do not.